### PR TITLE
Add support for local installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ sudo renova install
 
 ## Usage
 ```bash
-sudo renova
+# Update both globally and locally
+sudo renova && renova
 ```
 
 ## Uninstall

--- a/main.go
+++ b/main.go
@@ -191,10 +191,11 @@ func uninstall() error {
 
 func main() {
 	app := &cli.App{
-		Name:    "renova",
-		Usage:   "Update all your packages",
-		Version: "v1.1.0",
-		Suggest: true,
+		Name:        "renova",
+		Usage:       "Update all your packages",
+		Description: "renova updates packages for the current user. To update global packages, run \"sudo renova\", to update local packages, run \"renova\".",
+		Version:     "v1.1.0",
+		Suggest:     true,
 		Action: func(ctx *cli.Context) error {
 			return UpdateAll()
 		},


### PR DESCRIPTION
Adds support for locally installed managers, such as rustup. Using `sudo` updates all global packages, running as a normal user updates all local packages.

## Other Changes
- Bump version number to v1.1.0
- Improve help flag
- Update README with new changes